### PR TITLE
Fix. Handle destroy response properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    economic-rest (0.6.5)
+    economic-rest (0.6.6)
       activesupport (~> 8.0)
       rest-client (~> 2.1)
 

--- a/lib/economic/response.rb
+++ b/lib/economic/response.rb
@@ -30,7 +30,7 @@ module Economic
             self_link: parsed["self"],
             pagination: Economic::Response::Pagination.from_hash(parsed["pagination"])
           )
-        else
+        elsif parsed.key?("self")
           # find model class
           endpoint = parsed["self"][30..].split("/")[0..-2].join("/")
           model_class = model_class_from_endpoint(endpoint)
@@ -40,6 +40,8 @@ module Economic
             self_link: parsed["self"],
             meta_data: parsed["metaData"]
           )
+        else
+          true
         end
       end
 

--- a/lib/economic/rest/version.rb
+++ b/lib/economic/rest/version.rb
@@ -1,5 +1,5 @@
 module Economic
   module Rest
-    VERSION = "0.6.6".freeze
+    VERSION = "0.6.7".freeze
   end
 end

--- a/test/repo_test.rb
+++ b/test/repo_test.rb
@@ -114,7 +114,7 @@ module Economic
       describe "#destroy" do
         it "destroys a record" do
           stub_request(:delete, "https://restapi.e-conomic.com/basics/3")
-            .to_return(status: 204, body: "", headers: {})
+            .to_return(status: 200, body: {message: "Deleted invoice.", deletedCount: 1, deletedItems: [{draftInvoiceNumber: 347, self: "https://restapi.e-conomic.com/invoices/drafts/347"}]}.to_json, headers: {})
 
           response = Economic::Repos::Basic.new.destroy(3)
 


### PR DESCRIPTION
Stop raising exceptions when using the destroy method on Economic::Repo subclasses.